### PR TITLE
fix: Redraw Cart & Checkout after Payment is finished

### DIFF
--- a/starter/src/assets/front.js
+++ b/starter/src/assets/front.js
@@ -134,6 +134,10 @@ document.querySelector('.pay').addEventListener('click', (e) => {
         `;
     }
 
+    // force cart and checkout redraw after pay function completes
+    drawCart();
+    drawCheckout();
+
     paymentSummary.append(div);
 });
 


### PR DESCRIPTION
Issue currently exists when the payment is complete and the cart is emptied during the pay() function, the cart won't be redrawn and appear to contain the previous items.

Commit forces drawCart() and drawCheckout() to run after each pay() function